### PR TITLE
DDG-23: Add basic signal handler

### DIFF
--- a/include/SignalHandler.h
+++ b/include/SignalHandler.h
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace ddgen
+{
+class SignalHandler
+{
+public:
+    SignalHandler();
+    bool shallStop() const;
+    virtual ~SignalHandler() = default;
+private:
+    static void _handleSignals(int sigNum);
+    void _registerSignals() const;
+public:
+    static bool _shallStop;
+    static bool _shallConfigurationUpdate;
+};
+}

--- a/src/SignalHandler.cpp
+++ b/src/SignalHandler.cpp
@@ -1,0 +1,46 @@
+#include "SignalHandler.h"
+
+#include <iostream>
+#include <signal.h>
+
+namespace ddgen
+{
+bool SignalHandler::_shallStop = false;
+bool SignalHandler::_shallConfigurationUpdate = false;
+
+SignalHandler::SignalHandler() {
+    _registerSignals();
+}
+
+bool SignalHandler::shallStop() const {
+    return _shallStop;
+}
+
+void SignalHandler::_registerSignals() const {
+    struct sigaction new_action;
+
+    new_action.sa_handler = SignalHandler::_handleSignals;
+    sigemptyset(&new_action.sa_mask);
+    new_action.sa_flags = 0;
+
+    sigaction(SIGHUP, &new_action, NULL);
+    sigaction(SIGTERM, &new_action, NULL);
+}
+
+void SignalHandler::_handleSignals(int sigNum) {
+    switch (sigNum) {
+    case SIGTERM:
+        std::cout << "SIGTERM signal received, quitting ..." << std::endl;
+        _shallStop = true;
+        break;
+    case SIGHUP:
+        std::cout << "SIGHUP signal received, requesting a configuration reread ..." << std::endl;
+        _shallConfigurationUpdate = true;
+        break;
+    default:
+        std::cout << "Ungandled signal received " << sigNum << std::endl;
+    }
+}
+
+}
+

--- a/src/ddgen.cpp
+++ b/src/ddgen.cpp
@@ -1,6 +1,7 @@
 #include "CallLoggerFactory.h"
 #include "CallStorageFactory.h"
 #include "ConsumerFactory.h"
+#include "SignalHandler.h"
 
 #include "callleg.h"
 #include "programoptions.h"
@@ -40,6 +41,8 @@ bool SleepSystemUsec(unsigned long long int sleep_usec)
 
 int main(int argc, char* argv[])
 {
+    ddgen::SignalHandler signalHandler;
+
     ddgen::ProgramOptions program_options(argc, argv);
 
     auto callLogger = ddgen::CallLoggerFactory::CreateCallLogger( { program_options.useDb, program_options.dbPath, program_options.stackName } );
@@ -113,6 +116,11 @@ int main(int argc, char* argv[])
         const auto ellapsed_time_in_ms = std::chrono::duration_cast<std::chrono::milliseconds>(current_time - start_time).count();
         if (ellapsed_time_in_ms > simulationDuration) {
             std::cout << "Simulation time " << program_options.simulationDuration << " is over" << std::endl;
+            break;
+        }
+
+        if (signalHandler.shallStop()) {
+            std::cout << "Quiting after a simulation time " << ellapsed_time_in_ms << " ms" << std::endl;
             break;
         }
     }


### PR DESCRIPTION
Add basic signal handler in order to ease kubernetes operations.
Kubernetes uses SIGTERM in pod modifications and scaling. It is
better to stop operations in response to SIGTERM rather than being
hardkilled after 30 sec with SIGKILL